### PR TITLE
Use orientation method to flip the board.

### DIFF
--- a/js/board-controls-bottom.js
+++ b/js/board-controls-bottom.js
@@ -6,7 +6,7 @@ $('#btn-flip-board').click(function() {
   if (typeof board.flip == 'function') {
     board.flip();
   } else {
-    console.log('Board flip is not supported.');
+    board.setOrientation('flip');
   }
 });
 
@@ -16,7 +16,7 @@ $('#btn-switch-sides').click(function() {
   if (typeof board.flip == 'function') {
     board.flip();
   } else {
-    console.log('Board flip is not supported.');
+    board.setOrientation('flip');
   }
 
   if (playerSide == 'w') {


### PR DESCRIPTION
Caustique chessboard indeed doesn't have much documentation but it does have support for fliping the orientation of the board. I removed the "not supported" messages and put the call to flip function instead.