### PR TITLE
Resolving issues with historical and AI to Player

### DIFF
--- a/js/board-controls-bottom.js
+++ b/js/board-controls-bottom.js
@@ -48,7 +48,10 @@ $('#btn-save-pgn').on('click', function () {
 // Disable engine
 
 $('#btn-engine-disable').on('click', function () {
-  if ($('#btn-engine-disable').hasClass('active')) {
+  /*
+    Deleting the functionality of toggle from AI to Player. Only commenting the lines.
+  */
+  /*if ($('#btn-engine-disable').hasClass('active')) {
     $('#btn-engine-disable').removeClass('active');
     $('#btn-engine-disable').text("AI");
     engineDisabled = false;
@@ -59,7 +62,7 @@ $('#btn-engine-disable').on('click', function () {
     $('#btn-engine-disable').addClass('active');
     $('#btn-engine-disable').text("Player");
     engineDisabled = true;
-  }
+  }*/
 });
 
 // Show hint where to make move

--- a/js/board-init.js
+++ b/js/board-init.js
@@ -59,7 +59,8 @@ function listMoves() {
     console.log('History: show turn ' + $(this).attr('turn'));
     moves = JSON.parse(localStorage.getItem('boardHistory'));
     console.log(moves[turnN-1]);
-    loadBoard(moves[turnN-1], true);
+    /*Deleting the functionality of load the board when click on historical. Only commenting the lines.*/
+    //loadBoard(moves[turnN-1], true);
   });
 }
 


### PR DESCRIPTION
Deleting the functionality of load the board when click on historical. Only commenting the lines. Issue: https://github.com/LabinatorSolutions/stockfish-chess-web-gui/issues/23

Deleting the functionality of toggle from AI to Player. Only commenting the lines. Issue: https://github.com/LabinatorSolutions/stockfish-chess-web-gui/issues/24