### PR TITLE
fix typo: save PNG to save PGN

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                         <div class="buttons">
                             <button id="btn-switch-sides" title="Switch Sides"><i class="icon"></i></button>
                             <button id="btn-flip-board" title="Flip Board"><i class="icon"></i></button>
-                            <button id="btn-save-pgn" title="Save PNG"><i class="icon"></i></button>
+                            <button id="btn-save-pgn" title="Save PGN"><i class="icon"></i></button>
                             <button id="btn-engine-disable" title="Engine Toggle (On/Off)">AI</button>
                             <button id="btn-show-hint" title="Show Hint"><i class="icon"></i></button>
                             <button id="btn-take-back" class="disabled" title="Take Back"><i class="icon"></i></button>


### PR DESCRIPTION
If we hover over download as PGN button, it shows save PNG instead of save PGN. This PR fixes that typo.